### PR TITLE
Add Real Jobs From Anywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Other lists.
 - [People-First Jobs](https://peoplefirstjobs.com)
 - [Privacy-First Jobs](https://privacyfirstjobs.com) - Focus on the privacy industry.
 - [PyCoder's Jobs](https://www.pythonjobshq.com) - Focus on Python.
+- [Real Jobs From Anywhere](https://realjobsfromanywhere.com/) - Curated remote job board with verified remote-first positions.
 - [Real Work From Anywhere](https://www.realworkfromanywhere.com) - 100% remote.
 - [Remote.co](https://remote.co)
 - [Remote Army](https://remotearmy.io/)


### PR DESCRIPTION
## Description
Adding [Real Jobs From Anywhere](https://realjobsfromanywhere.com/) to the "Other websites" section.

## About Real Jobs From Anywhere
Real Jobs From Anywhere is a curated remote job board that focuses on verified remote-first positions across various tech and non-tech roles. The platform emphasizes quality over quantity, helping job seekers find genuine remote opportunities from companies that truly embrace remote work culture.

## Changes Made
- Added "Real Jobs From Anywhere" to the "Other websites" section
- Maintained alphabetical order in the list
- Included a brief description: "Curated remote job board with verified remote-first positions"
- Used consistent formatting with other entries

Thank you for maintaining this valuable resource!