### PR TITLE
Add Hanzilla Jobs Remote Canada

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Other lists.
 - [Futureshaper](https://futureshaper.com) - Focus on innovative companies.
 - [Hubstaff Talent](https://hubstafftalent.net)
 - [Gamejob.works](https://gamejobs.work) - Focus on gaming.
+- [Hanzilla Jobs Remote Canada](https://jobs.hanzilla.co/locations/remote/) - Daily-updated Canadian student and recent-grad remote jobs across internships, co-ops, new grad, junior, and entry-level roles.
 - [Inclusively Remote](https://inclusivelyremote.com/)
 - [Infosec Jobs](https://infosec-jobs.com/) - Focus on cybersecurity.
 - [Italia Remote](https://italiaremote.com/companies) - List of remote-friendly italian companies.


### PR DESCRIPTION
## Summary

- Adds Hanzilla Jobs Remote Canada to the remote/job-board resource list.
- Uses the Remote Canada deep link so readers land on remote-friendly Canadian student/recent-grad roles.

## Why

Hanzilla Jobs is a free, daily-updated Canadian student/recent-grad jobs board covering internships, co-ops, new grad, junior, and entry-level roles across tech plus adjacent fields like finance, engineering, business, and sciences. The remote Canada page is a useful fit for readers looking specifically for remote opportunities with a Canadian focus.

## Check

- README-only change
- Link verified live: https://jobs.hanzilla.co/locations/remote/
